### PR TITLE
Return list of endpoints at root / GET route

### DIFF
--- a/__tests__/integration/endpoints.test.js
+++ b/__tests__/integration/endpoints.test.js
@@ -33,17 +33,26 @@ describe("Integration tests: API endpoints",
                 )
 
                 it("responds to GET at `/` with a welcome message and a description",
-                async () => {
-                    // Act
-                    const response = await request(server).get('/')
+                    async () => {
+                        // Act
+                        const response = await request(server).get('/')
 
-                    // Assert
-                    expect(response.body.message).toBe("Welcome to the Points API!")
-                    expect(response.body.description).toBe("An API that stores information on points awarded to (or deducted from!) Fossians.")
-                }
+                        // Assert
+                        expect(response.body.message).toBe("Welcome to the Points API!")
+                        expect(response.body.description).toBe("An API that stores information on points awarded to (or deducted from!) Fossians.")
+                    }
                 )
 
-                
+                it("returns a list of the available endpoints",
+                    async () => {
+                        // Act
+                        const response = await request(server).get('/')
+
+                        // Assert
+                        expect(response.body.endpoints).toBeInstanceOf(Array);  // is an array
+                        expect(response.body.endpoints).toContainEqual({ method: 'GET', path: '/', success_status: '200' })
+                    }
+                )
             }
         )
 

--- a/app.js
+++ b/app.js
@@ -11,7 +11,10 @@ app.get(
     '/',
     (req, res) => res.status(200).json({
         message: "Welcome to the Points API!",
-        description: "An API that stores information on points awarded to (or deducted from!) Fossians."
+        description: "An API that stores information on points awarded to (or deducted from!) Fossians.",
+        endpoints: [
+            { method: 'GET', path: '/', success_status: '200' }
+        ]
     })
 )
 


### PR DESCRIPTION
Add the single currently available endpoint in the data returned from the GET `/`. 